### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/Selangk/c956cb81-fb61-4f92-ae78-7f279a886d1b/82a23396-8d20-4479-89cb-cb37d053acf4/_apis/work/boardbadge/45420d7a-11ca-4ab3-9d0c-ccc581fd320c)](https://dev.azure.com/Selangk/c956cb81-fb61-4f92-ae78-7f279a886d1b/_boards/board/t/82a23396-8d20-4479-89cb-cb37d053acf4/Microsoft.RequirementCategory)
 # asmlopenhack
 for hackathon


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/Selangk/c956cb81-fb61-4f92-ae78-7f279a886d1b/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.